### PR TITLE
Add Strava auth helper with templated OAuth flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,17 @@ GPXBridge needs a Strava API application and an OAuth refresh token in order to 
 4. Save. You will now see your **Client ID** and **Client Secret**.
 
 ### 2. Authorize Yourself and Capture a Refresh Token
+
+Run the built-in helper to guide you through the OAuth dance:
+
+```bash
+uv run gpxbridge strava auth
+```
+
+The command prompts for your client ID/secret (or reads `STRAVA_CLIENT_ID` / `STRAVA_CLIENT_SECRET`), opens Strava's authorization page, and listens on `http://localhost:8721` for the redirect. When you approve the app it prints ready-to-copy exports for `STRAVA_CLIENT_ID`, `STRAVA_CLIENT_SECRET`, and `STRAVA_REFRESH_TOKEN`.
+
+Prefer the manual route? Follow the original flow:
+
 1. Visit this authorization URL in your browser, replacing `YOUR_CLIENT_ID` with the number you just received:
    ```
    https://www.strava.com/oauth/authorize?client_id=YOUR_CLIENT_ID&response_type=code&redirect_uri=http://localhost&approval_prompt=force&scope=activity:read_all

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "pydantic-settings>=2.7.1",
     "arrow>=1.3.0",
     "loguru>=0.7.2",
+    "jinja2>=3.1.4",
     "python-slugify>=8.0.4",
     "tenacity>=9.0.0",
 ]
@@ -28,6 +29,9 @@ build-backend = "setuptools.build_meta"
 [tool.setuptools]
 packages = ["src"]
 package-dir = {"" = "."}
+
+[tool.setuptools.package-data]
+"src.strava" = ["templates/*.html"]
 
 [dependency-groups]
 dev = [

--- a/src/strava/oauth.py
+++ b/src/strava/oauth.py
@@ -243,10 +243,16 @@ def _exchange_code_for_tokens(
         response.raise_for_status()
         logger.success("Successfully exchanged authorization code for tokens")
         data = response.json()
-        sanitized_payload = {}
+        sanitized_payload: Dict[str, Any] = {}
         for key, value in data.items():
-            if key == "athlete" or "token" in key.lower():
+            if "token" in key.lower():
                 sanitized_payload[key] = "<redacted>"
+            elif key == "athlete" and isinstance(value, dict):
+                sanitized_payload[key] = {
+                    field: value[field]
+                    for field in ("id", "firstname", "lastname")
+                    if field in value
+                }
             else:
                 sanitized_payload[key] = value
         logger.debug(

--- a/src/strava/oauth.py
+++ b/src/strava/oauth.py
@@ -1,0 +1,326 @@
+"""Utilities to drive Strava OAuth authorization flows."""
+
+from __future__ import annotations
+
+import json
+import secrets
+import threading
+from datetime import datetime, timezone
+from dataclasses import dataclass
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from typing import Any, Dict, Optional
+from urllib.parse import parse_qs, urlencode, urlparse
+
+import requests
+from jinja2 import Environment, PackageLoader, TemplateNotFound, select_autoescape
+from loguru import logger
+
+DEFAULT_SCOPE = "activity:read_all"
+DEFAULT_TIMEOUT = 180
+_DEFAULT_EXPORT_COMMAND = "uv run gpxbridge strava export --count 5 --output-dir ./exports"
+
+_TEMPLATE_ENV: Environment | None = None
+
+
+class OAuthError(RuntimeError):
+    """Raised when the Strava OAuth flow fails."""
+
+
+@dataclass
+class OAuthTokens:
+    """Container for tokens returned by Strava."""
+
+    access_token: str
+    refresh_token: str
+    expires_at: int
+    expires_in: int
+    token_type: str
+    athlete: Dict[str, Any]
+
+    @classmethod
+    def from_response(cls, payload: Dict[str, Any]) -> "OAuthTokens":
+        try:
+            return cls(
+                access_token=str(payload["access_token"]),
+                refresh_token=str(payload["refresh_token"]),
+                expires_at=int(payload["expires_at"]),
+                expires_in=int(payload["expires_in"]),
+                token_type=str(payload.get("token_type", "Bearer")),
+                athlete=dict(payload.get("athlete", {})),
+            )
+        except (KeyError, TypeError, ValueError) as exc:
+            raise OAuthError(
+                "Unexpected response while exchanging OAuth code for tokens"
+            ) from exc
+
+
+def _get_template_env() -> Environment:
+    """Return a cached Jinja environment for OAuth templates."""
+
+    global _TEMPLATE_ENV
+    if _TEMPLATE_ENV is None:
+        _TEMPLATE_ENV = Environment(
+            loader=PackageLoader("src.strava", "templates"),
+            autoescape=select_autoescape(["html", "xml"]),
+            enable_async=False,
+            trim_blocks=True,
+            lstrip_blocks=True,
+        )
+    return _TEMPLATE_ENV
+
+
+def _render_template(template_name: str, context: Dict[str, Any]) -> str:
+    """Render a template and surface missing template errors as OAuth issues."""
+
+    try:
+        template = _get_template_env().get_template(template_name)
+    except TemplateNotFound as exc:
+        raise OAuthError(f"Missing OAuth template: {template_name}") from exc
+    return template.render(**context)
+
+
+def _build_authorization_url(
+    client_id: str, redirect_uri: str, scope: str, state: str
+) -> str:
+    params = {
+        "client_id": client_id,
+        "response_type": "code",
+        "redirect_uri": redirect_uri,
+        "approval_prompt": "force",
+        "scope": scope,
+        "state": state,
+    }
+    encoded = urlencode(params)
+    return f"https://www.strava.com/oauth/authorize?{encoded}"
+
+
+class _OAuthCallbackHandler(BaseHTTPRequestHandler):
+    """HTTP handler that captures the OAuth `code` query parameter."""
+
+    server_version = "StravaOAuthHelper/1.0"
+    error_content_type = "text/html"
+
+    def log_message(self, format: str, *args: Any) -> None:  # noqa: A003 - signature fixed
+        # Silence BaseHTTPRequestHandler's noisy logging
+        logger.debug("OAuth callback server: " + format % args)
+
+    def do_GET(self) -> None:  # noqa: N802 - required by BaseHTTPRequestHandler
+        server: "_OAuthHTTPServer" = self.server  # type: ignore[assignment]
+        parsed = urlparse(self.path)
+
+        if parsed.path not in ("/", "", "/callback"):
+            self.send_error(404, "Unknown path")
+            return
+
+        params = parse_qs(parsed.query)
+        state = params.get("state", [None])[0]
+        if state != server.expected_state:
+            logger.error("Received OAuth callback with unexpected state: {}", state)
+            self.send_error(400, "State mismatch. Please retry the authorization.")
+            return
+
+        if "error" in params:
+            error_code = params.get("error", ["unknown"])[0]
+            logger.error("User denied OAuth authorization: {}", error_code)
+            self._write_html(
+                200,
+                "<h1>Authorization cancelled</h1><p>You can close this window.</p>",
+            )
+            server.error = OAuthError(
+                "Authorization was cancelled. Re-run the helper to try again."
+            )
+            server.signal.set()
+            return
+
+        code = params.get("code", [None])[0]
+        if not code:
+            logger.error("OAuth callback missing authorization code")
+            self.send_error(
+                400, "Missing authorization code. Please retry the authorization."
+            )
+            return
+
+        try:
+            tokens = _exchange_code_for_tokens(
+                server.client_id, server.client_secret, str(code)
+            )
+        except OAuthError as exc:
+            logger.error("Token exchange failed during OAuth callback: {}", exc)
+            server.error = exc
+            server.signal.set()
+            self._write_html(200, _render_error_html(str(exc)))
+            return
+
+        server.authorization_code = str(code)
+        server.tokens = tokens
+        server.signal.set()
+        self._write_html(
+            200,
+            _render_success_html(server.client_id, server.client_secret, tokens),
+        )
+
+    def _write_html(self, status: int, html: str) -> None:
+        payload = html.encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "text/html; charset=utf-8")
+        self.send_header("Content-Length", str(len(payload)))
+        self.end_headers()
+        self.wfile.write(payload)
+
+
+class _OAuthHTTPServer(HTTPServer):
+    """HTTP server that captures the OAuth authorization code."""
+
+    def __init__(
+        self,
+        address: tuple[str, int],
+        expected_state: str,
+        client_id: str,
+        client_secret: str,
+    ):
+        super().__init__(address, _OAuthCallbackHandler)
+        self.expected_state = expected_state
+        self.client_id = client_id
+        self.client_secret = client_secret
+        self.authorization_code: Optional[str] = None
+        self.tokens: Optional[OAuthTokens] = None
+        self.signal = threading.Event()
+        self.error: Optional[Exception] = None
+
+
+def _wait_for_callback(server: _OAuthHTTPServer, timeout: int) -> None:
+    logger.info(
+        "Waiting for Strava to redirect back with an authorization code (timeout={}s)",
+        timeout,
+    )
+    if not server.signal.wait(timeout=timeout):
+        raise OAuthError(
+            "Timed out waiting for Strava authorization. Did you approve the app?"
+        )
+
+    if server.error:
+        raise server.error
+
+    if not server.authorization_code:
+        raise OAuthError(
+            "Did not receive an authorization code from Strava. Please try again."
+        )
+
+
+def _run_callback_server(
+    client_id: str, client_secret: str, port: int, state: str, timeout: int
+) -> tuple[str, Optional[OAuthTokens]]:
+    server = _OAuthHTTPServer(("localhost", port), state, client_id, client_secret)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+
+    try:
+        _wait_for_callback(server, timeout)
+        if not server.authorization_code:
+            raise OAuthError(
+                "Did not receive an authorization code from Strava. Please try again."
+            )
+        return server.authorization_code, server.tokens
+    finally:
+        server.shutdown()
+        thread.join(timeout=5)
+        server.server_close()
+
+
+def _exchange_code_for_tokens(
+    client_id: str, client_secret: str, code: str
+) -> OAuthTokens:
+    token_url = "https://www.strava.com/oauth/token"
+    payload = {
+        "client_id": client_id,
+        "client_secret": client_secret,
+        "code": code,
+        "grant_type": "authorization_code",
+    }
+
+    try:
+        response = requests.post(token_url, data=payload, timeout=30)
+        response.raise_for_status()
+        logger.success("Successfully exchanged authorization code for tokens")
+        data = response.json()
+        logger.debug(
+            "Token exchange response: {}",
+            json.dumps({k: v for k, v in data.items() if k != "access_token"}, indent=2),
+        )
+        return OAuthTokens.from_response(data)
+    except requests.exceptions.RequestException as exc:
+        raise OAuthError(
+            "Failed to exchange authorization code for tokens: {}".format(exc)
+        ) from exc
+
+
+def run_oauth_flow(
+    client_id: str,
+    client_secret: str,
+    *,
+    scope: str = DEFAULT_SCOPE,
+    port: int = 8721,
+    open_browser: bool = True,
+    timeout: int = DEFAULT_TIMEOUT,
+) -> OAuthTokens:
+    """Run a Strava OAuth dance and return refresh/access tokens."""
+
+    state = secrets.token_urlsafe(16)
+    redirect_uri = f"http://localhost:{port}"
+    auth_url = _build_authorization_url(client_id, redirect_uri, scope, state)
+
+    logger.info("Starting Strava OAuth flow")
+    logger.info("Authorization URL: {}", auth_url)
+
+    if open_browser:
+        logger.info("Opening browser for authorization...")
+        try:
+            import webbrowser
+
+            webbrowser.open(auth_url, new=1, autoraise=True)
+        except Exception as exc:  # noqa: BLE001 - best effort
+            logger.warning("Failed to open browser automatically: {}", exc)
+            logger.warning("Copy the URL above into your browser to continue.")
+    else:
+        logger.info("Open the URL above in your browser to authorize access.")
+
+    try:
+        code, tokens = _run_callback_server(
+            client_id, client_secret, port, state, timeout
+        )
+    except OSError as exc:
+        raise OAuthError(
+            f"Could not start local callback server on port {port}: {exc}"
+        ) from exc
+    logger.info("Received authorization code from Strava; completing flow")
+    if tokens is None:
+        tokens = _exchange_code_for_tokens(client_id, client_secret, code)
+    return tokens
+
+
+def _render_success_html(
+    client_id: str, client_secret: str, tokens: OAuthTokens
+) -> str:
+    env_exports = [
+        f'export STRAVA_CLIENT_ID="{client_id}"',
+        f'export STRAVA_CLIENT_SECRET="{client_secret}"',
+        f'export STRAVA_REFRESH_TOKEN="{tokens.refresh_token}"',
+    ]
+    expires_at_iso = datetime.fromtimestamp(
+        tokens.expires_at, tz=timezone.utc
+    ).isoformat()
+
+    context: Dict[str, Any] = {
+        "env_exports": env_exports,
+        "export_command": _DEFAULT_EXPORT_COMMAND,
+        "expires_at": expires_at_iso,
+        "athlete": tokens.athlete or {},
+    }
+    return _render_template("oauth_success.html", context)
+
+
+def _render_error_html(message: str) -> str:
+    return _render_template("oauth_error.html", {"message": message})
+
+
+__all__ = ["run_oauth_flow", "OAuthTokens", "OAuthError", "DEFAULT_SCOPE"]

--- a/src/strava/oauth.py
+++ b/src/strava/oauth.py
@@ -243,9 +243,15 @@ def _exchange_code_for_tokens(
         response.raise_for_status()
         logger.success("Successfully exchanged authorization code for tokens")
         data = response.json()
+        sanitized_payload = {}
+        for key, value in data.items():
+            if key == "athlete" or "token" in key.lower():
+                sanitized_payload[key] = "<redacted>"
+            else:
+                sanitized_payload[key] = value
         logger.debug(
-            "Token exchange response: {}",
-            json.dumps({k: v for k, v in data.items() if k != "access_token"}, indent=2),
+            "Token exchange response (sanitized): {}",
+            json.dumps(sanitized_payload, indent=2),
         )
         return OAuthTokens.from_response(data)
     except requests.exceptions.RequestException as exc:

--- a/src/strava/templates/oauth_error.html
+++ b/src/strava/templates/oauth_error.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>GPXBridge Authorization Error</title>
+    <style>
+      body {
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+        margin: 2rem;
+        background: #fef2f2;
+        color: #9b1c1c;
+      }
+      .panel {
+        max-width: 640px;
+        margin: 0 auto;
+        padding: 1.75rem;
+        background: white;
+        border-radius: 12px;
+        box-shadow: 0 10px 30px rgba(185, 28, 28, 0.12);
+      }
+      h1 {
+        margin-top: 0;
+      }
+      .hint {
+        margin-top: 1rem;
+        color: #b91c1c;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="panel">
+      <h1>Authorization failed</h1>
+      <p>{{ message }}</p>
+      <p class="hint">Return to the terminal for details and try again.</p>
+    </div>
+  </body>
+</html>

--- a/src/strava/templates/oauth_success.html
+++ b/src/strava/templates/oauth_success.html
@@ -1,0 +1,142 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>GPXBridge Authorization Complete</title>
+    <style>
+      body {
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+        margin: 2rem;
+        color: #1f2933;
+        background: #f5f7fa;
+      }
+      .panel {
+        max-width: 720px;
+        margin: 0 auto;
+        padding: 2rem;
+        background: white;
+        border-radius: 12px;
+        box-shadow: 0 10px 30px rgba(15, 23, 42, 0.1);
+      }
+      pre {
+        background: #0f172a;
+        color: #e2e8f0;
+        padding: 1rem;
+        border-radius: 8px;
+        overflow-x: auto;
+        font-size: 0.9rem;
+      }
+      button {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.5rem;
+        margin-top: 0.75rem;
+        padding: 0.6rem 1rem;
+        background: #2563eb;
+        color: white;
+        border: none;
+        border-radius: 6px;
+        font-size: 0.95rem;
+        cursor: pointer;
+      }
+      button:active {
+        transform: translateY(1px);
+      }
+      .hint {
+        margin-top: 1.5rem;
+        font-size: 0.95rem;
+        line-height: 1.6;
+      }
+      .secondary {
+        color: #52606d;
+      }
+      .success {
+        font-size: 1.4rem;
+        font-weight: 600;
+        margin-bottom: 1rem;
+      }
+      .athlete {
+        margin-top: 1.5rem;
+        padding: 1.25rem;
+        background: #f8fafc;
+        border-radius: 8px;
+        border: 1px solid #d2d6dc;
+      }
+      .athlete h2 {
+        margin-top: 0;
+        font-size: 1rem;
+        text-transform: uppercase;
+        letter-spacing: 0.04em;
+      }
+      .athlete dl {
+        margin: 0;
+        display: grid;
+        grid-template-columns: max-content auto;
+        gap: 0.5rem 1rem;
+        font-size: 0.95rem;
+      }
+      .athlete dt {
+        font-weight: 600;
+        color: #364152;
+      }
+      .athlete dd {
+        margin: 0;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="panel">
+      <div class="success">Authorization complete!</div>
+      <p>
+        Hop back to your terminal. We've printed these exports there too, but you
+        can copy them from here if you prefer:
+      </p>
+      <pre id="env-block">{{ env_exports | join('\n') }}</pre>
+      <button id="copy-btn" type="button">Copy exports</button>
+      <div class="hint">
+        When the exports are set, run:
+        <pre id="export-command">{{ export_command }}</pre>
+      </div>
+      <div class="hint secondary">
+        Access token expires at <strong>{{ expires_at }}</strong> (UTC).
+      </div>
+      {% if athlete %}
+      <div class="athlete">
+        <h2>Authorized athlete</h2>
+        <dl>
+          {% if athlete.get('id') %}
+          <dt>ID</dt>
+          <dd>{{ athlete.get('id') }}</dd>
+          {% endif %}
+          {% if athlete.get('firstname') or athlete.get('lastname') %}
+          <dt>Name</dt>
+          <dd>{{ athlete.get('firstname', '') }} {{ athlete.get('lastname', '') }}</dd>
+          {% endif %}
+          {% if athlete.get('city') or athlete.get('country') %}
+          <dt>Location</dt>
+          <dd>
+            {{ athlete.get('city', 'Unknown') }}{% if athlete.get('city') and athlete.get('country') %}, {% endif %}{{ athlete.get('country', '') }}
+          </dd>
+          {% endif %}
+        </dl>
+      </div>
+      {% endif %}
+    </div>
+    <script>
+      const button = document.getElementById('copy-btn');
+      button?.addEventListener('click', async () => {
+        const text = document.getElementById('env-block')?.innerText;
+        if (!text) return;
+        try {
+          await navigator.clipboard.writeText(text);
+          button.textContent = 'Copied!';
+          setTimeout(() => { button.textContent = 'Copy exports'; }, 2500);
+        } catch (error) {
+          button.textContent = 'Copy failed';
+          setTimeout(() => { button.textContent = 'Copy exports'; }, 2500);
+        }
+      });
+    </script>
+  </body>
+</html>

--- a/uv.lock
+++ b/uv.lock
@@ -163,6 +163,7 @@ dependencies = [
     { name = "arrow" },
     { name = "click" },
     { name = "gpxpy" },
+    { name = "jinja2" },
     { name = "loguru" },
     { name = "pre-commit" },
     { name = "pydantic" },
@@ -189,6 +190,7 @@ requires-dist = [
     { name = "arrow", specifier = ">=1.3.0" },
     { name = "click", specifier = ">=8.2.1" },
     { name = "gpxpy", specifier = ">=1.6.2" },
+    { name = "jinja2", specifier = ">=3.1.4" },
     { name = "loguru", specifier = ">=0.7.2" },
     { name = "pre-commit", specifier = ">=4.0.1" },
     { name = "pydantic", specifier = ">=2.10.4" },
@@ -260,6 +262,18 @@ wheels = [
 ]
 
 [[package]]
+name = "jinja2"
+version = "3.1.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
+]
+
+[[package]]
 name = "loguru"
 version = "0.7.3"
 source = { registry = "https://pypi.org/simple" }
@@ -270,6 +284,34 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/3a/05/a1dae3dffd1116099471c643b8924f5aa6524411dc6c63fdae648c4f1aca/loguru-0.7.3.tar.gz", hash = "sha256:19480589e77d47b8d85b2c827ad95d49bf31b0dcde16593892eb51dd18706eb6", size = 63559, upload-time = "2024-12-06T11:20:56.608Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0c/29/0348de65b8cc732daa3e33e67806420b2ae89bdce2b04af740289c5c6c8c/loguru-0.7.3-py3-none-any.whl", hash = "sha256:31a33c10c8e1e10422bfd431aeb5d351c7cf7fa671e3c4df004162264b28220c", size = 61595, upload-time = "2024-12-06T11:20:54.538Z" },
+]
+
+[[package]]
+name = "markupsafe"
+version = "3.0.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b2/97/5d42485e71dfc078108a86d6de8fa46db44a1a9295e89c5d6d4a06e23a62/markupsafe-3.0.2.tar.gz", hash = "sha256:ee55d3edf80167e48ea11a923c7386f4669df67d7994554387f84e7d8b0a2bf0", size = 20537, upload-time = "2024-10-18T15:21:54.129Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/83/0e/67eb10a7ecc77a0c2bbe2b0235765b98d164d81600746914bebada795e97/MarkupSafe-3.0.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:ba9527cdd4c926ed0760bc301f6728ef34d841f405abf9d4f959c478421e4efd", size = 14274, upload-time = "2024-10-18T15:21:24.577Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/6d/9409f3684d3335375d04e5f05744dfe7e9f120062c9857df4ab490a1031a/MarkupSafe-3.0.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:f8b3d067f2e40fe93e1ccdd6b2e1d16c43140e76f02fb1319a05cf2b79d99430", size = 12352, upload-time = "2024-10-18T15:21:25.382Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/f5/6eadfcd3885ea85fe2a7c128315cc1bb7241e1987443d78c8fe712d03091/MarkupSafe-3.0.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:569511d3b58c8791ab4c2e1285575265991e6d8f8700c7be0e88f86cb0672094", size = 24122, upload-time = "2024-10-18T15:21:26.199Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/91/96cf928db8236f1bfab6ce15ad070dfdd02ed88261c2afafd4b43575e9e9/MarkupSafe-3.0.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:15ab75ef81add55874e7ab7055e9c397312385bd9ced94920f2802310c930396", size = 23085, upload-time = "2024-10-18T15:21:27.029Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/cf/c9d56af24d56ea04daae7ac0940232d31d5a8354f2b457c6d856b2057d69/MarkupSafe-3.0.2-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f3818cb119498c0678015754eba762e0d61e5b52d34c8b13d770f0719f7b1d79", size = 22978, upload-time = "2024-10-18T15:21:27.846Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/9f/8619835cd6a711d6272d62abb78c033bda638fdc54c4e7f4272cf1c0962b/MarkupSafe-3.0.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:cdb82a876c47801bb54a690c5ae105a46b392ac6099881cdfb9f6e95e4014c6a", size = 24208, upload-time = "2024-10-18T15:21:28.744Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/bf/176950a1792b2cd2102b8ffeb5133e1ed984547b75db47c25a67d3359f77/MarkupSafe-3.0.2-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:cabc348d87e913db6ab4aa100f01b08f481097838bdddf7c7a84b7575b7309ca", size = 23357, upload-time = "2024-10-18T15:21:29.545Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/4f/9a02c1d335caabe5c4efb90e1b6e8ee944aa245c1aaaab8e8a618987d816/MarkupSafe-3.0.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:444dcda765c8a838eaae23112db52f1efaf750daddb2d9ca300bcae1039adc5c", size = 23344, upload-time = "2024-10-18T15:21:30.366Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/55/c271b57db36f748f0e04a759ace9f8f759ccf22b4960c270c78a394f58be/MarkupSafe-3.0.2-cp313-cp313-win32.whl", hash = "sha256:bcf3e58998965654fdaff38e58584d8937aa3096ab5354d493c77d1fdd66d7a1", size = 15101, upload-time = "2024-10-18T15:21:31.207Z" },
+    { url = "https://files.pythonhosted.org/packages/29/88/07df22d2dd4df40aba9f3e402e6dc1b8ee86297dddbad4872bd5e7b0094f/MarkupSafe-3.0.2-cp313-cp313-win_amd64.whl", hash = "sha256:e6a2a455bd412959b57a172ce6328d2dd1f01cb2135efda2e4576e8a23fa3b0f", size = 15603, upload-time = "2024-10-18T15:21:32.032Z" },
+    { url = "https://files.pythonhosted.org/packages/62/6a/8b89d24db2d32d433dffcd6a8779159da109842434f1dd2f6e71f32f738c/MarkupSafe-3.0.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:b5a6b3ada725cea8a5e634536b1b01c30bcdcd7f9c6fff4151548d5bf6b3a36c", size = 14510, upload-time = "2024-10-18T15:21:33.625Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/06/a10f955f70a2e5a9bf78d11a161029d278eeacbd35ef806c3fd17b13060d/MarkupSafe-3.0.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:a904af0a6162c73e3edcb969eeeb53a63ceeb5d8cf642fade7d39e7963a22ddb", size = 12486, upload-time = "2024-10-18T15:21:34.611Z" },
+    { url = "https://files.pythonhosted.org/packages/34/cf/65d4a571869a1a9078198ca28f39fba5fbb910f952f9dbc5220afff9f5e6/MarkupSafe-3.0.2-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4aa4e5faecf353ed117801a068ebab7b7e09ffb6e1d5e412dc852e0da018126c", size = 25480, upload-time = "2024-10-18T15:21:35.398Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/e3/90e9651924c430b885468b56b3d597cabf6d72be4b24a0acd1fa0e12af67/MarkupSafe-3.0.2-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c0ef13eaeee5b615fb07c9a7dadb38eac06a0608b41570d8ade51c56539e509d", size = 23914, upload-time = "2024-10-18T15:21:36.231Z" },
+    { url = "https://files.pythonhosted.org/packages/66/8c/6c7cf61f95d63bb866db39085150df1f2a5bd3335298f14a66b48e92659c/MarkupSafe-3.0.2-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d16a81a06776313e817c951135cf7340a3e91e8c1ff2fac444cfd75fffa04afe", size = 23796, upload-time = "2024-10-18T15:21:37.073Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/35/cbe9238ec3f47ac9a7c8b3df7a808e7cb50fe149dc7039f5f454b3fba218/MarkupSafe-3.0.2-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:6381026f158fdb7c72a168278597a5e3a5222e83ea18f543112b2662a9b699c5", size = 25473, upload-time = "2024-10-18T15:21:37.932Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/32/7621a4382488aa283cc05e8984a9c219abad3bca087be9ec77e89939ded9/MarkupSafe-3.0.2-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:3d79d162e7be8f996986c064d1c7c817f6df3a77fe3d6859f6f9e7be4b8c213a", size = 24114, upload-time = "2024-10-18T15:21:39.799Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/80/0985960e4b89922cb5a0bac0ed39c5b96cbc1a536a99f30e8c220a996ed9/MarkupSafe-3.0.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:131a3c7689c85f5ad20f9f6fb1b866f402c445b220c19fe4308c0b147ccd2ad9", size = 24098, upload-time = "2024-10-18T15:21:40.813Z" },
+    { url = "https://files.pythonhosted.org/packages/82/78/fedb03c7d5380df2427038ec8d973587e90561b2d90cd472ce9254cf348b/MarkupSafe-3.0.2-cp313-cp313t-win32.whl", hash = "sha256:ba8062ed2cf21c07a9e295d5b8a2a5ce678b913b45fdf68c32d95d6c1291e0b6", size = 15208, upload-time = "2024-10-18T15:21:41.814Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/65/6079a46068dfceaeabb5dcad6d674f5f5c61a6fa5673746f42a9f4c233b3/MarkupSafe-3.0.2-cp313-cp313t-win_amd64.whl", hash = "sha256:e444a31f8db13eb18ada366ab3cf45fd4b31e4db1236a4448f68778c1d1a5a2f", size = 15739, upload-time = "2024-10-18T15:21:42.784Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- add an interactive  command with browser-friendly templates
- include a Strava OAuth helper module and package Jinja2-rendered success/error pages
- document the helper and ship the new dependency

## Testing
- uv run ruff check
- uv run pytest